### PR TITLE
REFACTOR: Refactoring V2 for -b option and header size.

### DIFF
--- a/tarsau/functions.h
+++ b/tarsau/functions.h
@@ -27,20 +27,33 @@ int createHeader(const char *filename, const char *archive_file_name) {
         perror("Error getting file stats");
         return -1;
     }
-    int perms = fileStat.st_mode & 0777;
+    unsigned int perms = fileStat.st_mode & 0777;
     long size = fileStat.st_size;
 
-    FILE *archive_file = fopen(archive_file_name, "a+");
+    // Open the archive file in "r+" mode to allow read and write
+    FILE *archive_file = fopen(archive_file_name, "r+");
     if (archive_file == NULL) {
-        perror("Error opening archive file");
-        return -1;
+        // If opening in "r+" fails (probably because the file doesn't exist), try "w" to create a new file
+        archive_file = fopen(archive_file_name, "w");
+        if (archive_file == NULL) {
+            perror("Error opening archive file");
+            return -1;
+        }
     }
 
+    size_t header_size = 0;
+    fprintf(archive_file, "%010ld|", header_size);
+    fseek(archive_file, 0, SEEK_END);
     fprintf(archive_file, "%s,%o,%ld|", filename, perms, size);
+    header_size = ftell(archive_file);
+    fseek(archive_file, 0, SEEK_SET);
+    fprintf(archive_file, "%010ld|", header_size);
+    fflush(archive_file);
     fclose(archive_file);
 
     return 0;
 }
+
 
 
 long getSize(const char *filename) {
@@ -70,8 +83,7 @@ int readAndWrite(const char *file_to_be_archived_name, const char *archive_file_
 
     char *line = NULL;
     size_t len = 0;
-    ssize_t read;
-    while ((read = getline(&line, &len, file_to_be_archived)) != -1) {
+    while (getline(&line, &len, file_to_be_archived) != -1) {
         fputs(line, archive_file);
     }
 
@@ -84,12 +96,21 @@ int readAndWrite(const char *file_to_be_archived_name, const char *archive_file_
 
 int endsWith(const char *str, const char *suffix) {
     if (!str || !suffix)
-        return 0;
+        return -1;
     size_t str_len = strlen(str);
     size_t suffix_len = strlen(suffix);
     if (suffix_len > str_len)
-        return 0;
-    return strncmp(str + str_len - suffix_len, suffix, suffix_len) == 0;
+        return -1;
+    int compare_strings = strncmp(str + str_len - suffix_len, suffix, suffix_len);
+    return compare_strings == 0 ? 0 : compare_strings;
+}
+
+void truncateFile(char *file_name){
+    FILE *file = fopen(file_name, "w");
+    if (file == NULL) {
+        perror("Error: opening file to truncate");
+    }
+    fclose(file);
 }
 
 


### PR DESCRIPTION
- A bug in the function that prevented adding the '.sau' extension again if the archive file already ended with the '.sau' extension has been fixed.
- The `truncateFile` function has been added to truncate an existing archive file if its name is provided in the command line arguments.
- Added 10-byte `header_size` info into the header.
- Handled the error case where there are no arguments after the option `-b`.